### PR TITLE
Update transaction hash in README.md

### DIFF
--- a/fiber-js/README.md
+++ b/fiber-js/README.md
@@ -62,7 +62,7 @@ fiber:
             args: 0x3cb7c0304fe53f75bb5727e2484d0beae4bd99d979813c6fc97c3cca569f10f6
         - cell_dep:
             out_point:
-              tx_hash: 0x5a5288769cecde6451cb5d301416c297a6da43dc3ac2f3253542b4082478b19b # ckb_auth
+              tx_hash: 0x12c569a258dd9c5bd99f632bb8314b1263b90921ba31496467580d6b79dd14a7 # ckb_auth
               index: 0x0
             dep_type: code
     - name: CommitmentLock
@@ -77,7 +77,7 @@ fiber:
             args: 0xf7e458887495cf70dd30d1543cad47dc1dfe9d874177bf19291e4db478d5751b
         - cell_dep:
             out_point:
-              tx_hash: 0x5a5288769cecde6451cb5d301416c297a6da43dc3ac2f3253542b4082478b19b #ckb_auth
+              tx_hash: 0x12c569a258dd9c5bd99f632bb8314b1263b90921ba31496467580d6b79dd14a7 #ckb_auth
               index: 0x0
             dep_type: code
 


### PR DESCRIPTION
In fiber-js, the value of the `txhash` field in the contract must be consistent with the value specified in `config/testnet/config.yml`.

https://github.com/nervosnetwork/fiber/blob/e190193463e672477b7159969968d5c7f1d43819/config/testnet/config.yml#L59